### PR TITLE
mec5_zapps_pub: Update manifest for CMSIS v6 and HAL v05

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,7 +21,8 @@ manifest:
         # strictly needed by the application.
         name-allowlist:
           - cmsis      # required by the ARM port
+          - cmsis_6
     - name: hal_microchip
       path: modules/hal/microchip
       remote: origin
-      revision: mec5_hal_v0p4
+      revision: mec5_hal_v05


### PR DESCRIPTION
We updated the manifest to pull down Zephyr's CMSIS v6 and Microchip HAL v05 branch.